### PR TITLE
get HTML lexer from makeup registry, don't hardcode

### DIFF
--- a/lib/makeup/lexers/eex_lexer/application.ex
+++ b/lib/makeup/lexers/eex_lexer/application.ex
@@ -7,7 +7,6 @@ defmodule Makeup.Lexers.EExLexer.Application do
   alias Makeup.Lexers.{
     EExLexer,
     HEExLexer,
-    HTMLLexer,
     ElixirLexer
   }
 
@@ -21,13 +20,12 @@ defmodule Makeup.Lexers.EExLexer.Application do
     )
 
     Registry.register_lexer(EExLexer,
-      options: [outer_lexer: HTMLLexer],
+      options: [outer_lexer: &MakeupEEx.dynamic_html_lexer/0],
       names: ["html_eex", "html.eex"],
       extensions: ["html.eex"]
     )
 
     Registry.register_lexer(HEExLexer,
-      options: [],
       names: ["heex"],
       extensions: ["heex"]
     )

--- a/lib/makeup/lexers/eex_lexer/testing.ex
+++ b/lib/makeup/lexers/eex_lexer/testing.ex
@@ -4,8 +4,7 @@ defmodule Makeup.Lexers.EExLexer.Testing do
   alias Makeup.Lexers.{
     EExLexer,
     HEExLexer,
-    ElixirLexer,
-    HTMLLexer
+    ElixirLexer
   }
 
   alias Makeup.Lexer.Postprocess
@@ -34,8 +33,10 @@ defmodule Makeup.Lexers.EExLexer.Testing do
 
   @spec lex_html(any) :: list
   def lex_html(text) do
+    {lexer, _opts} = Makeup.Registry.get_lexer_by_name("html")
+
     text
-    |> HTMLLexer.lex(group_prefix: "group-out")
+    |> lexer.lex(group_prefix: "group-out")
     |> Postprocess.token_values_to_binaries()
     |> Enum.map(fn {ttype, meta, value} -> {ttype, Map.delete(meta, :language), value} end)
   end
@@ -43,7 +44,10 @@ defmodule Makeup.Lexers.EExLexer.Testing do
   @spec lex_html_eex(any) :: list
   def lex_html_eex(text) do
     text
-    |> EExLexer.lex(group_prefix: "group", outer_lexer: HTMLLexer)
+    |> EExLexer.lex(
+      group_prefix: "group",
+      outer_lexer: fn -> Makeup.Registry.get_lexer_by_name("html") end
+    )
     |> Postprocess.token_values_to_binaries()
     |> Enum.map(fn {ttype, meta, value} -> {ttype, Map.delete(meta, :language), value} end)
   end
@@ -51,7 +55,7 @@ defmodule Makeup.Lexers.EExLexer.Testing do
   @spec lex_heex(any) :: list
   def lex_heex(text) do
     text
-    |> HEExLexer.lex(group_prefix: "group", outer_lexer: HTMLLexer)
+    |> HEExLexer.lex(group_prefix: "group")
     |> Postprocess.token_values_to_binaries()
     |> Enum.map(fn {ttype, meta, value} -> {ttype, Map.delete(meta, :language), value} end)
   end

--- a/lib/makeup_eex.ex
+++ b/lib/makeup_eex.ex
@@ -2,4 +2,26 @@ defmodule MakeupEEx do
   @moduledoc """
   Documentation for `MakeupEEx`.
   """
+
+  alias Makeup.Registry
+
+  @doc false
+  def dynamic_html_lexer do
+    case {Registry.get_lexer_by_name("html"), Registry.get_lexer_by_extension("html")} do
+      {nil, nil} ->
+        raise """
+        The HEEx / EEx+HTML lexer requires an HTML lexer to be registered. You can do this for example by including
+
+            {:makeup_html, "~> 1.0"}
+
+        in your project's dependencies.
+        """
+
+      {nil, lexer_tuple} ->
+        lexer_tuple
+
+      {lexer_tuple, _} ->
+        lexer_tuple
+    end
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,8 @@ defmodule MakeupEEx.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),
-      description: "(H)EEx lexer for makeup"
+      description: "(H)EEx lexer for makeup",
+      test_ignore_filters: [&String.starts_with?(&1, "test/fixtures")]
     ]
   end
 
@@ -40,7 +41,7 @@ defmodule MakeupEEx.MixProject do
       {:nimble_parsec, "~> 1.2"},
       # Sub-languages
       {:makeup_elixir, "~> 1.0"},
-      {:makeup_html, "~> 0.1.0 or ~> 1.0"},
+      {:makeup_html, "~> 0.1.0 or ~> 1.0", optional: true},
       # Docs
       {:ex_doc, "~> 0.27", only: :dev, runtime: false}
     ]


### PR DESCRIPTION
Removes the dependency on makeup_html (now optional) and allows any library to be used for the HTML part of HEEx, even when using ExDoc.

Adds a separate postprocessing step to handle differences between makeup_html and other HTML lexers.