### PR TITLE
allow language in heex postprocess to be a binary

### DIFF
--- a/lib/makeup/lexers/heex_lexer.ex
+++ b/lib/makeup/lexers/heex_lexer.ex
@@ -162,8 +162,9 @@ defmodule Makeup.Lexers.HEExLexer do
   # other HTML Lexers (e.g. makeup_syntect) classify opening tags as :name_tag
   # Treat any tag name as possible HEEx component
   defp heex_postprocess([
-         {:name_tag, %{language: :html} = attrs, tag_name} | tokens
-       ]) do
+         {:name_tag, %{language: language} = attrs, tag_name} | tokens
+       ])
+       when language in [:html, "html"] do
     tag_tokens =
       case ElixirLexer.lex(tag_name) do
         # MyMod.function -> remote component


### PR DESCRIPTION
@josevalim sorry I noticed this too late, the HEEx postprocessing actually did not work with makeup_syntect, because the language in the meta is always a string there (and I'd like to keep it that way). I think allowing this here is reasonable.